### PR TITLE
Add Matrix room shield to ReadMe

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # community-topics
 
+![](https://img.shields.io/matrix/community:ansible.com.svg?server_fqdn=ansible-accounts.ems.host&label=Discuss%20at%20%23community:ansible.com&logo=matrix)
+
 This repository contains topics that will be discussed and voted by the Ansible Community and the [Ansible Community Steering Committee](https://docs.ansible.com/ansible/devel/community/steering/community_steering_committee.html) asynchronously.
 
 If you want to discuss an idea, improvements or submit new Policy/Proposals & New Collection Inclusion Requests then create a new [issue](https://github.com/ansible-community/community-topics/issues) in this repo as a topic.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # community-topics
 
-![](https://img.shields.io/matrix/community:ansible.com.svg?server_fqdn=ansible-accounts.ems.host&label=Discuss%20at%20%23community:ansible.com&logo=matrix)
+[![Discuss at #community:ansible.com on Matrix](https://img.shields.io/matrix/community:ansible.com.svg?server_fqdn=ansible-accounts.ems.host&label=Discuss%20at%20%23community:ansible.com&logo=matrix)](https://matrix.to/#/#community:ansible.com)
 
 This repository contains topics that will be discussed and voted by the Ansible Community and the [Ansible Community Steering Committee](https://docs.ansible.com/ansible/devel/community/steering/community_steering_committee.html) asynchronously.
 


### PR DESCRIPTION
This is a demo of using Shields.io to add direct links to our chat spaces from our README files. We could potentially make use of this in any of our repos, where an appropriate chatroom target exists. For this repo, the community working group room seemed appropriate.

These shields appear to render well on Galaxy too, since it ingests the README files, which should help direct users to the right place depending on what content they're using - gives maintainers more ways to signpost people, which I like.

Thoughts?