### PR TITLE
meeting-people.py: Fix meeting-people.txt finding

### DIFF
--- a/meeting/meeting-people.py
+++ b/meeting/meeting-people.py
@@ -12,7 +12,7 @@ else:
 
 
 def main():
-    path = Path(__file__).parent.joinpath("meeting-people.txt")
+    path = Path(__file__).resolve().parent.joinpath("meeting-people.txt")
     with path.open(encoding="utf-8") as fp:
         people = sorted(
             [


### PR DESCRIPTION
We need to resolve symlinks to find the actual directory when the script
is e.g. symlinked to ~/.local/bin.
