### PR TITLE
switch meeting time to 18:00 UTC

### DIFF
--- a/meeting/README.md
+++ b/meeting/README.md
@@ -1,6 +1,6 @@
 # Ansible Community Meeting
 
-The Ansible Community Meeting happens weekly on Wednesdays at 19:00 UTC in
+The Ansible Community Meeting happens weekly on Wednesdays at 18:00 UTC in
 #ansible-community (libera.chat) /
 [#community:ansible.com](https://matrix.to/#/#community:ansible.com) (Matrix).
 


### PR DESCRIPTION
Summer time begins for (most of) the Europe on 26 March. It started in
the US back on 12 March. After last time change, we informally agreed to
move the meeting according to winter and summer time (i.e. meet at 19:00
in the winter and 18:00 in the summer).

Relates: https://github.com/ansible/community/pull/691
