### PR TITLE
Improve Bullhorn removal vote anounecement

### DIFF
--- a/scripts/removal_process/bullhorn_2nd.sh
+++ b/scripts/removal_process/bullhorn_2nd.sh
@@ -7,4 +7,6 @@ then
     exit 1
 fi
 
-echo "As mentioned in [The Bullhorn #$1](https://mailchi.mp/redhat/the-bullhorn-$1), we consider \`$2\` an effectively unmaintained collection. Therefore, we've opened a community / steering committee [vote]($3) on removing it from the Ansible $4 community package."
+echo "As mentioned in [The Bullhorn #$1](https://mailchi.mp/redhat/the-bullhorn-$1), we consider \`$2\` an effectively unmaintained collection. Therefore, we've opened a community / steering committee [vote]($3) on removing it from the Ansible $4 community package.
+
+Please note that you can still manually install the collection with \`ansible-galaxy collection install $2\` even when it has been removed from Ansible."


### PR DESCRIPTION
We have the information that the collection can still be installed via galaxy in both [the first announcement in Bullhorn](https://github.com/ansible-community/community-topics/blob/f65f92c845416b09c7a3967f4d6b7f24f6dfa88a/scripts/removal_process/bullhorn_1st.sh) (where we're threatening to remove the collection from the community package) and [the third announcement](https://github.com/ansible-community/community-topics/blob/f65f92c845416b09c7a3967f4d6b7f24f6dfa88a/scripts/removal_process/bullhorn_3rd.sh) when the vote has been accepted.

I think we should also add this to the second announcement on Bullhorn, the vote itself.