### PR TITLE
community_topics_workflow.md: change to conduct them on Forum

### DIFF
--- a/community_topics_workflow.md
+++ b/community_topics_workflow.md
@@ -63,15 +63,15 @@ Any user can [created a topic](https://forum.ansible.com/new-topic?title=topic%2
 - [ ] If the topic implies some actions (if it does not, just mark this as complete), the Committee person:
 
   - [ ] Assigns the topic to a person responsible for performing the actions.
-  - [ ] Add the `being_implemented` tag to the topic.
+  - [ ] Add the `being-implemented` tag to the topic.
 - [ ] After the topic is implemented, the assignee:
 
   - [ ] Comments on the topic that the work is done.
-  - [ ] Removes the `being_implemented` tag.
+  - [ ] Removes the `being-implemented` tag.
   - [ ] Add the `implemented` tag.
 - [ ] If the topic implies actions related to the future Ansible Community package releases (for example, a collection exclusion), the Committee person:
 
-  - [ ] Adds the `scheduled_for_future_release` tag to the topic.
+  - [ ] Adds the `scheduled-for-future-release` tag to the topic.
   - [ ] Checks if there's a corresponding milestone in the [ansible-build-data](https://github.com/ansible-community/ansible-build-data/milestones) repository. If there's no milestone, the person creates it.
   - [ ] Creates an issue in ansible-build-data that references the topic in community-topics, and adds it to the milestone.
 

--- a/community_topics_workflow.md
+++ b/community_topics_workflow.md
@@ -12,7 +12,7 @@ The Workflow is a set of actions that need to be done successively within the co
 
 ## Creating a topic
 
-Any user can [created a topic](https://forum.ansible.com/new-topic?title=topic%20title&body=topic%20body&category=project&tags=steering-committee) tagged with `steering-committee` under the `Project Discussions` category in the [Ansible Forum](https://forum.ansible.com/). A steering committee member can tag the forum post with `community-meeting` to put it on the meeting agenda.
+Any user can [create a topic](https://forum.ansible.com/new-topic?title=topic%20title&body=topic%20body&category=project&tags=steering-committee) tagged with `steering-committee` under the `Project Discussions` category in the [Ansible Forum](https://forum.ansible.com/). A steering committee member can tag the forum post with `community-meeting` to put it on the meeting agenda.
 
 ## Workflow
 

--- a/community_topics_workflow.md
+++ b/community_topics_workflow.md
@@ -74,7 +74,6 @@ Any user can [created a topic](https://forum.ansible.com/new-topic?title=topic%2
   - [ ] Adds the `scheduled_for_future_release` tag to the topic.
   - [ ] Checks if there's a corresponding milestone in the [ansible-build-data](https://github.com/ansible-community/ansible-build-data/milestones) repository. If there's no milestone, the person creates it.
   - [ ] Creates an issue in ansible-build-data that references the topic in community-topics, and adds it to the milestone.
-- [ ] A Committee person moves the topic to the `Resolved` column on the [Board](https://github.com/orgs/ansible-community/projects/2/views/5) and closes the topic.
 
 ### Tools
 

--- a/community_topics_workflow.md
+++ b/community_topics_workflow.md
@@ -12,7 +12,7 @@ The Workflow is a set of actions that need to be done successively within the co
 
 ## Creating a topic
 
-Any user can [create a topic](https://forum.ansible.com/new-topic?title=topic%20title&body=topic%20body&category=project&tags=steering-committee) tagged with `steering-committee` under the `Project Discussions` category in the [Ansible Forum](https://forum.ansible.com/). A steering committee member can tag the forum post with `community-meeting` to put it on the meeting agenda.
+Any user can [create a topic](https://forum.ansible.com/new-topic?title=topic%20title&body=topic%20body&category=project&tags=community-wg) tagged with `community-wg` under the `Project Discussions` category in the [Ansible Forum](https://forum.ansible.com/). A steering committee member can tag the forum post with `community-wg-nextmtg` to put it on the meeting agenda.
 
 ## Workflow
 
@@ -26,7 +26,7 @@ Any user can [create a topic](https://forum.ansible.com/new-topic?title=topic%20
 
 - [ ] If the topic is ready to be discussed, the Committee person:
 
-  - [ ] Adds the `community-meeting` tag if it needs to be discussed in the meeting.
+  - [ ] Adds the `community-wg-nextmtg` tag if it needs to be discussed in the meeting.
   - [ ] Opens the discussion by adding a comment asking the Community and the Committee to take part in it.
 - [ ] No synchronous discussion is needed (there are no blockers, complications, confusion, or impasses).
 

--- a/community_topics_workflow.md
+++ b/community_topics_workflow.md
@@ -8,9 +8,11 @@ This document describes the Ansible Community Topics workflow (hereinafter `Work
 
 The Workflow is a set of actions that need to be done successively within the corresponding time frames.
 
-After a topic is created, a Steering Committee member (hereinafter `Committee person`) copies the Workflow into the topic and, along the way, marks the checkboxes as complete to track the progress, see and plan the following actions needed to get the topic resolved within acceptable time.
-
 **Note:** If you have any ideas on how the Workflow can be improved, please create an issue in this repository or pull request against this document.
+
+## Creating a topic
+
+Any user can [created a topic](https://forum.ansible.com/new-topic?title=topic%20title&body=topic%20body&category=project&tags=steering-committee) tagged with `steering-committee` under the `Project Discussions` category in the [Ansible Forum](https://forum.ansible.com/). A steering committee member can tag the forum post with `community-meeting` to put it on the meeting agenda.
 
 ## Workflow
 
@@ -18,15 +20,13 @@ After a topic is created, a Steering Committee member (hereinafter `Committee pe
 
 ### Preparation stage
 
-- [ ] A Committee person checks the topic's content, asks the author / other persons to provide additional information if needed (adds the `waiting` label in this case).
-- [ ] Adds the topic to the [Board](https://github.com/orgs/ansible-community/projects/2/views/1).
+- [ ] A Committee person checks the topic's content, asks the author/other persons to provide additional information if needed.
 
 ### Discussion stage
 
 - [ ] If the topic is ready to be discussed, the Committee person:
 
-  - [ ] Adds the `discussion_topic` label.
-  - [ ] Moves the topic to the `In Discussion` column on the [Board](https://github.com/orgs/ansible-community/projects/2/views/5).
+  - [ ] Adds the `community-meeting` tag if it needs to be discussed in the meeting.
   - [ ] Opens the discussion by adding a comment asking the Community and the Committee to take part in it.
 - [ ] No synchronous discussion is needed (there are no blockers, complications, confusion, or impasses).
 
@@ -34,19 +34,29 @@ After a topic is created, a Steering Committee member (hereinafter `Committee pe
 
 - [ ] Depending on the topic's complexity, 1-2 weeks after the discussion was opened, the Committee person formulates vote options based on the prior discussion and gives participants reasonable amount of time to propose changes to the options (no longer than a week). The person summarizes the options in a comment and also establishes a date when the vote begins if there are no objections about the options / vote date.
 - [ ] In the vote date, the vote starts with the comment of a Committee person which opens the vote and establishes a date when the vote ends ($CURRENT_DATE + no longer than 21 days; usually it should not exceed 14 days, 21 days should only be used if it is known that a lot of interested persons will likely not have time to vote in a 14 days period).
-- [ ] The Committee person labels the topic with the `active-vote` label and moves the topic to the `Active Vote` column on the [Board](https://github.com/orgs/ansible-community/projects/2/views/5).
+- [ ] The Committee person labels the topic with the `active-vote` tag.
 - [ ] The Committee person adds `[Vote ends on $YYYY-MM-DD]` to the beginning of the topic's description.
+- A vote is actually two polls, one for the Steering Committee, one for everyone else. To create a vote in a topic:
+  - [ ] Create a new post in the topic.
+  - [ ] Click the `gear` button in the composer and select Build Poll.
+  - [ ] Click the `gear` in the Poll Builder for advanced mode.
+  - [ ] Set up the options (generally this will be Single Choice but other poll types can be used).
+  - [ ] Title it "Steering Committee vote" and "Limit voting" to the `Steering Committee`.
+  - [ ] Do not set the close date because this cannot be changed later.
+  - [ ] Results should be "Always Visible" unless there is some good reason for the SC votes not to be public.
+  - [ ] Submit the poll (the BBcode will appear in the post) and then repeat the above for the second poll.
+    - [ ] Title should be "Community vote".
+    - [ ] No group limitation.
+    - [ ] Results "Staff only" (i.e. an anonymous vote, but admins can check if there are concerns).
 
 ### Voting result stage
 
 - [ ] The next day after the last day of the vote, the Committee person:
 
-  - [ ] Removes the `active-vote` label.
+  - [ ] Removes the `active-vote` tag.
   - [ ] Add a comment that the vote ended.
   - [ ] Changes the beginning of the topic's description to `[Vote ended]`.
-  - [ ] Counts the votes separating ones made by Community and made by Committee and creates a summary comment containing the result.
-  - [ ] Asks another Committee person to count the votes and provide the summary.
-- [ ] At least two Steering Committee members count the votes and summarize the result in comments.
+  - [ ] Creates a summary comment declaring the vote result.
 - [ ] The vote's result and the final decision are announced via the [Bullhorn](https://github.com/ansible/community/issues/546).
 
 ### Implementation stage
@@ -54,15 +64,15 @@ After a topic is created, a Steering Committee member (hereinafter `Committee pe
 - [ ] If the topic implies some actions (if it does not, just mark this as complete), the Committee person:
 
   - [ ] Assigns the topic to a person responsible for performing the actions.
-  - [ ] Add the `being_implemented` label to the topic.
+  - [ ] Add the `being_implemented` tag to the topic.
 - [ ] After the topic is implemented, the assignee:
 
   - [ ] Comments on the topic that the work is done.
-  - [ ] Removes the `being_implemented` label.
-  - [ ] Add the `implemented` label.
+  - [ ] Removes the `being_implemented` tag.
+  - [ ] Add the `implemented` tag.
 - [ ] If the topic implies actions related to the future Ansible Community package releases (for example, a collection exclusion), the Committee person:
 
-  - [ ] Adds the `scheduled_for_future_release` label to the topic.
+  - [ ] Adds the `scheduled_for_future_release` tag to the topic.
   - [ ] Checks if there's a corresponding milestone in the [ansible-build-data](https://github.com/ansible-community/ansible-build-data/milestones) repository. If there's no milestone, the person creates it.
   - [ ] Creates an issue in ansible-build-data that references the topic in community-topics, and adds it to the milestone.
 - [ ] A Committee person moves the topic to the `Resolved` column on the [Board](https://github.com/orgs/ansible-community/projects/2/views/5) and closes the topic.

--- a/community_topics_workflow.md
+++ b/community_topics_workflow.md
@@ -47,7 +47,6 @@ Any user can [created a topic](https://forum.ansible.com/new-topic?title=topic%2
   - [ ] Submit the poll (the BBcode will appear in the post) and then repeat the above for the second poll.
     - [ ] Title should be "Community vote".
     - [ ] No group limitation.
-    - [ ] Results "Staff only" (i.e. an anonymous vote, but admins can check if there are concerns).
 
 ### Voting result stage
 


### PR DESCRIPTION
To implement https://forum.ansible.com/t/draft-for-sc-voting-process-on-the-forum/1410

Removed all board mentions as it doesn't work:)

Closes: https://github.com/ansible-community/community-topics/issues/273