### PR TITLE
Close polls after voting

### DIFF
--- a/community_topics_workflow.md
+++ b/community_topics_workflow.md
@@ -52,6 +52,7 @@ Any user can [create a topic](https://forum.ansible.com/new-topic?title=topic%20
 
 - [ ] The next day after the last day of the vote, the Committee person:
 
+  - [ ] Closes the polls.
   - [ ] Removes the `active-vote` tag.
   - [ ] Add a comment that the vote ended.
   - [ ] Changes the beginning of the topic's description to `[Vote ended]`.


### PR DESCRIPTION
The workflow says to not set the close date when creating the polls (because this cannot be changed later). But it doesn't say to close them once the vote has ended.

I don't like keeping those polls open so that people can still vote or even change their vote.