### PR TITLE
README: New topics on forum

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ From now on, if you want to discuss something that satisfies the scope then [cre
 
 All active votes in the Ansible Forum can be found using [the intersection of the `community-wg` and `active-vote` tags](https://forum.ansible.com/tags/intersection/community-wg/active-vote).
 
-You do **NOT** need any special status (for example, to be a Steering Committee member) to create the topics or take part in the discussions asynchronously in the topics or in the meetings (see below). Any opinions are equally welcome and appreciated!
+Community members may create topics, take part in asynchronous discussions, and vote! All opinions are equally welcome and appreciated. You do **NOT** need to be a Steering Committee member or to have any other special status to create topics or take part in the discussions asynchronously in the topics or in the meetings (see below). 
 
 ## Community meetings
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The **scope** of the topics includes changes impacting the Ansible community, co
 
 We decided to discuss those topics in the [Ansible forum](https://forum.ansible.com) in the future. However, we will not move the existing discussions to the forum and will keep to work on them here.
 
-From now on, if you want to discuss something that satisfies the scope then [create a new topic](https://forum.ansible.com/new-topic?title=topic%20title&body=topic%20body&category=project&tags=community-wg) tagged with `community-wg` under the `Project Discussions` category or [comment on an existing one](https://forum.ansible.com/search?expanded=true&q=%23project%20tags%3Acommunity-wg).
+From now on, if you want to discuss something that satisfies the scope then [create a new topic](https://forum.ansible.com/new-topic?category=project&tags=community-wg) tagged with `community-wg` under the `Project Discussions` category or [comment on an existing one](https://forum.ansible.com/tags/c/project/7/community-wg).
 
 All active votes in the Ansible Forum can be found using [the intersection of the `community-wg` and `active-vote` tags](https://forum.ansible.com/tags/intersection/community-wg/active-vote).
 

--- a/README.md
+++ b/README.md
@@ -2,11 +2,13 @@
 
 [![Discuss on Matrix at #community:ansible.com](https://img.shields.io/matrix/community:ansible.com.svg?server_fqdn=ansible-accounts.ems.host&label=Discuss%20on%20Matrix%20at%20%23community:ansible.com&logo=matrix)](https://matrix.to/#/#community:ansible.com)
 
-This repository contains topics that will be discussed and voted by the Ansible Community (all interested people) and the [Ansible Community Steering Committee](https://docs.ansible.com/ansible/devel/community/steering/community_steering_committee.html) asynchronously.
+This repository historically contained topics to be discussed and voted by the Ansible Community (all interested people) and the [Ansible Community Steering Committee](https://docs.ansible.com/ansible/devel/community/steering/community_steering_committee.html) asynchronously.
 
-The **scope** of the topics is changes impacting the Ansible community, contributor experience, Ansible Community package, and community collections.
+The **scope** of the topics was changes impacting the Ansible community, contributor experience, Ansible Community package, and community collections.
 
-If you want to discuss something that satisfies the scope then [create a new topic](https://github.com/ansible-community/community-topics/issues) or [comment on an existing one](https://github.com/ansible-community/community-topics/issues).
+We decided to discuss those topics in the [Ansible forum](https://forum.ansible.com) in the future. However, we will not move the existing discussions to the forum and will keep to work on them here.
+
+From now on, if you want to discuss something that satisfies the scope then [create a new topic](https://forum.ansible.com/new-topic?title=topic%20title&body=topic%20body&category=project&tags=community-wg) tagged with `community-wg` under the `Project Discussions` category or [comment on an existing one](https://forum.ansible.com/search?expanded=true&q=%23project%20tags%3Acommunity-wg).
 
 You do **NOT** need any special status (for example, to be a Steering Committee member) to create the topics or take part in the discussions asynchronously in the topics or in the meetings (see below). Any opinions are equally welcome and appreciated!
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 This repository historically contained topics to be discussed and voted by the Ansible Community (all interested people) and the [Ansible Community Steering Committee](https://docs.ansible.com/ansible/devel/community/steering/community_steering_committee.html) asynchronously.
 
-The **scope** of the topics was changes impacting the Ansible community, contributor experience, Ansible Community package, and community collections.
+The **scope** of the topics includes changes impacting the Ansible community, contributor experience, Ansible Community package, and community collections.
 
 We decided to discuss those topics in the [Ansible forum](https://forum.ansible.com) in the future. However, we will not move the existing discussions to the forum and will keep to work on them here.
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ We decided to discuss those topics in the [Ansible forum](https://forum.ansible.
 
 From now on, if you want to discuss something that satisfies the scope then [create a new topic](https://forum.ansible.com/new-topic?title=topic%20title&body=topic%20body&category=project&tags=community-wg) tagged with `community-wg` under the `Project Discussions` category or [comment on an existing one](https://forum.ansible.com/search?expanded=true&q=%23project%20tags%3Acommunity-wg).
 
+All active votes in the Ansible Forum can be found using [the intersection of the `community-wg` and `active-vote` tags](https://forum.ansible.com/tags/intersection/community-wg/active-vote).
+
 You do **NOT** need any special status (for example, to be a Steering Committee member) to create the topics or take part in the discussions asynchronously in the topics or in the meetings (see below). Any opinions are equally welcome and appreciated!
 
 ## Community meetings

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Discuss on Matrix at #community:ansible.com](https://img.shields.io/matrix/community:ansible.com.svg?server_fqdn=ansible-accounts.ems.host&label=Discuss%20on%20Matrix%20at%20%23community:ansible.com&logo=matrix)](https://matrix.to/#/#community:ansible.com)
 
-This repository historically contained topics to be discussed and voted by the Ansible Community (all interested people) and the [Ansible Community Steering Committee](https://docs.ansible.com/ansible/devel/community/steering/community_steering_committee.html) asynchronously.
+This repository contains historical topics for the Ansible Community (all interested people) and the [Ansible Community Steering Committee](https://docs.ansible.com/ansible/devel/community/steering/community_steering_committee.html) to discuss and vote on asynchronously.
 
 The **scope** of the topics includes changes impacting the Ansible community, contributor experience, Ansible Community package, and community collections.
 


### PR DESCRIPTION
We should update the README to make clear that new topics to discuss should be opened in the [Ansible forum](https://forum.ansible.com).